### PR TITLE
Remove unix references

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,14 +3,14 @@
 Each of the sample solutions can be built individually within Visual Studio. To build and test all solutions, a **Cake** (http://cakebuild.net) script is provided.
 The primary script that controls this is build.cake. We modify build.cake when we need to add new 
 targets or change the way the build is done. Normally build.cake is not invoked directly but through
-build.ps1 (on Windows) or build.sh (on Linux). These two scripts are provided by the Cake project
-and ensure that Cake is properly installed before trying to run the cake script. This helps the
-build to work on CI servers using newly created agents to run the build and we generally run it
+build.ps1. (Due to issues with mono's VBNC compiler, there is currently only a Windows build process.) 
+This script is provided by the Cake project and ensures that Cake is properly installed before trying to run the cake script. This helps the
+build to work on CI servers using newly created agents to run the build. We generally run it
 the same way on our own machines.
 
-The build shell script and build.cmd script are provided as an easy way to run the above commands.
-In addition to passing their arguments through to build.cake, they can supply added arguments
-through the CAKE_ARGS environment variable. The rest of this document will assume use of these commands.
+The build.cmd script is provided as an easy way to run build.ps1, from the command line.
+In addition to passing the arguments through to build.cake, it can supply added arguments
+through the CAKE_ARGS environment variable. The rest of this document will assume use of this script.
 
 There is one case in which use of the CAKE_ARGS environment variable will be essential, if not necessary.
 If you are running builds on a 32-bit Windows system, you must always supply the -Experimental argument

--- a/build.cake
+++ b/build.cake
@@ -144,21 +144,11 @@ void CheckForError(ref List<string> errorDetail)
 
 void BuildProject(string projPath, string configuration)
 {
-    if (IsRunningOnWindows())
-    {
-        MSBuild(projPath, new MSBuildSettings()
-            .SetConfiguration(configuration)
-            .SetMSBuildPlatform(MSBuildPlatform.Automatic)
-            .SetVerbosity(Verbosity.Minimal)
-            .SetNodeReuse(false));
-    }
-    else
-    {
-        XBuild(projPath, new XBuildSettings()
-            .WithTarget("Build")
-            .WithProperty("Configuration", configuration)
-            .SetVerbosity(Verbosity.Minimal));
-    }
+    MSBuild(projPath, new MSBuildSettings()
+        .SetConfiguration(configuration)
+        .SetMSBuildPlatform(MSBuildPlatform.Automatic)
+        .SetVerbosity(Verbosity.Minimal)
+        .SetNodeReuse(false));
 }
 
 string DirFrom(string filePath)


### PR DESCRIPTION
Remove the unix references from BUILDING.md and build.cake, as discussed in nunit/nunit-cpp-samples#4

Unix build is turned off in this repo due to a mono compiler bug - see #4 for details there.
